### PR TITLE
Fix specification url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Enum Definitions
 
-[Specification](http://rwaldron.github.io/enum-definitions/)
+[Specification](http://rwaldron.github.io/proposal-enum-definitions/)
 
 ## Status
 


### PR DESCRIPTION
According to repo rename the new Specification url is http://rwaldron.github.io/proposal-enum-definitions/
